### PR TITLE
Support Reserved Capacity

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,13 @@ resource "aws_codebuild_project" "this" {
         security_group_ids = var.docker_server_security_group_ids
       }
     }
+
+    dynamic "fleet" {
+      for_each = var.fleet_arn != null ? [1] : []
+      content {
+        fleet_arn = var.fleet_arn
+      }
+    }
   }
 
   logs_config {

--- a/variables.tf
+++ b/variables.tf
@@ -142,3 +142,9 @@ variable "vpc_security_group_ids" {
   description = "The list of Security Group IDs for AWS CodeBuild to launch ephemeral EC2 instances in."
   default     = []
 }
+
+variable "fleet_arn" {
+  type        = string
+  description = "The ARN of the AWS CodeBuild compute fleet to run the project on if using reserved capacity for project (example: arn:aws:codebuild:us-east-1:123456789012:fleet/my-codebuild-fleet)"
+  default     = null
+}


### PR DESCRIPTION
As a DevOps engineer managing a CB-hosted GHA project, I would like to be able to use the Reserved Capacity function of an AWS CodeBuild project.

# Functionality
- Build an [aws_codebuild_fleet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_fleet)  resource (e.g., see [PR](https://github.com/ccsq-isfcs/terraform-aws-codebuild-gha-runners/pull/9))
- Note the ARN
- Add the `fleet_arn` variable to the module argument
  - [ ] Verify the project is associated with the Compute Fleet and can build 
